### PR TITLE
added link to mybinder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # DNN
 DNN 
+
+Launch in browser:
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/llSourcell/DNN/master)


### PR DESCRIPTION
Users can launch DNN in the browser without having to clone etc.
[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/llSourcell/DNN/master)
